### PR TITLE
refactor: Remove redundant `inline` on constant functions

### DIFF
--- a/crates/citadel-consensus/src/threshold.rs
+++ b/crates/citadel-consensus/src/threshold.rs
@@ -33,7 +33,6 @@ pub const MAX_BYZANTINE: usize = 6;
 /// assert_eq!(validation_threshold(1), 1);   // Need the one neighbor
 /// assert_eq!(validation_threshold(20), 11); // Full BFT threshold
 /// ```
-#[inline]
 pub const fn validation_threshold(existing_neighbors: usize) -> usize {
     if existing_neighbors == 0 {
         return 0;
@@ -43,13 +42,11 @@ pub const fn validation_threshold(existing_neighbors: usize) -> usize {
 }
 
 /// Check if a connection count meets the threshold.
-#[inline]
 pub const fn meets_threshold(connections: usize, existing_neighbors: usize) -> bool {
     connections >= validation_threshold(existing_neighbors)
 }
 
 /// Calculate how many more connections are needed to meet threshold.
-#[inline]
 pub const fn connections_needed(current: usize, existing_neighbors: usize) -> usize {
     let threshold = validation_threshold(existing_neighbors);
     if current >= threshold {

--- a/crates/citadel-topology/src/hex.rs
+++ b/crates/citadel-topology/src/hex.rs
@@ -28,19 +28,16 @@ impl HexCoord {
     pub const ORIGIN: Self = Self { q: 0, r: 0, z: 0 };
 
     /// Create a new coordinate.
-    #[inline]
     pub const fn new(q: i64, r: i64, z: i64) -> Self {
         Self { q, r, z }
     }
 
     /// Create a planar coordinate (z = 0).
-    #[inline]
     pub const fn planar(q: i64, r: i64) -> Self {
         Self { q, r, z: 0 }
     }
 
     /// Compute the implicit third axis: s = -q - r.
-    #[inline]
     pub const fn s(&self) -> i64 {
         -self.q - self.r
     }

--- a/crates/citadel-topology/src/spiral.rs
+++ b/crates/citadel-topology/src/spiral.rs
@@ -37,13 +37,11 @@ impl SpiralIndex {
     pub const ORIGIN: Self = Self(0);
 
     /// Create from raw index.
-    #[inline]
     pub const fn new(index: u64) -> Self {
         Self(index)
     }
 
     /// Get the raw index value.
-    #[inline]
     pub const fn value(&self) -> u64 {
         self.0
     }
@@ -101,7 +99,6 @@ impl From<SpiralIndex> for u64 {
 ///
 /// - Ring 0: 1 slot (origin)
 /// - Ring n > 0: 6n slots
-#[inline]
 pub const fn slots_in_ring(ring: u64) -> u64 {
     if ring == 0 {
         1
@@ -115,7 +112,6 @@ pub const fn slots_in_ring(ring: u64) -> u64 {
 /// Formula: 1 + 3n(n+1)
 ///
 /// Proven in Lean: `CitadelProofs.Spiral.total_slots_formula`
-#[inline]
 pub const fn total_slots_through(ring: u64) -> u64 {
     1 + 3 * ring * (ring + 1)
 }

--- a/crates/citadel-topology/src/spiral3d.rs
+++ b/crates/citadel-topology/src/spiral3d.rs
@@ -50,12 +50,10 @@ pub struct Spiral3DIndex(pub u64);
 impl Spiral3DIndex {
     pub const ORIGIN: Self = Self(0);
 
-    #[inline]
     pub const fn new(index: u64) -> Self {
         Self(index)
     }
 
-    #[inline]
     pub const fn value(&self) -> u64 {
         self.0
     }
@@ -94,7 +92,6 @@ impl Spiral3DIndex {
 ///
 /// - Shell 0: 1
 /// - Shell n > 0: 18n² + 2
-#[inline]
 pub const fn slots_in_shell(n: u64) -> u64 {
     if n == 0 {
         1
@@ -106,7 +103,6 @@ pub const fn slots_in_shell(n: u64) -> u64 {
 /// Total slots through shell n (inclusive).
 ///
 /// Formula: 6n³ + 9n² + 5n + 1
-#[inline]
 pub const fn total_slots_through_shell(n: u64) -> u64 {
     6 * n * n * n + 9 * n * n + 5 * n + 1
 }
@@ -253,13 +249,11 @@ pub fn coord_to_spiral3d(coord: HexCoord) -> Spiral3DIndex {
 // ============ Helper functions for 2D enumeration within shells ============
 
 /// Total slots through ring n in 2D: 1 + 3n(n+1)
-#[inline]
 const fn total_slots_through_shell_2d(n: u64) -> u64 {
     1 + 3 * n * (n + 1)
 }
 
 /// Slots in 2D ring n: 6n (or 1 for n=0)
-#[inline]
 const fn slots_in_ring_2d(n: u64) -> u64 {
     if n == 0 { 1 } else { 6 * n }
 }


### PR DESCRIPTION
constant functions are compile time evaluated, making the inline annotation redundant. This falls under "easy-win", where such cruft can add up, making it a non-zero tech-debt payoff.