### PR TITLE
Count a filtered thing without an alloc collection

### DIFF
--- a/crates/citadel-consensus/src/convergence.rs
+++ b/crates/citadel-consensus/src/convergence.rs
@@ -136,11 +136,11 @@ pub fn check_exclusivity_invariant(
     }
 
     // Checks exclusivity without allocation
-    let thresh_filter = |(_, b)| *b >= FULL_THRESHOLD
+    let thresh_filter = |(_, b): &&(_, usize)| *b >= FULL_THRESHOLD;
     let second_thresh = bindings_by_node
         .iter()
         .filter(thresh_filter)
-        .nth(1)
+        .nth(1);
 
     if second_thresh.is_some() {
         return Err(ExclusivityViolation::MultipleOccupants {


### PR DESCRIPTION
The `collect` function, as per the implementation/documentation, allocates memory to create a new vector.

`count` will go through the entire iterator to count.

`nth` doesn't allocate, and as the count is low, will not traverse the iterator unecisarily.

This could fall under premature optimisation, and its highly likely that optimisations already do the theoretically ideal max perf, but this at least (theoretically) leaves nothing to chance.

